### PR TITLE
fix(admin): relabel Wicket Settings submenu to Settings

### DIFF
--- a/includes/admin/settings/class-wicket-settings.php
+++ b/includes/admin/settings/class-wicket-settings.php
@@ -99,7 +99,13 @@ if (!class_exists('Wicket_Settings')) {
 
             // Create Settings page with same slug as menu
             $settings = new WPSettings(__('Wicket Settings'), ('wicket-settings'));
-            $settings->set_menu_parent_slug('wicket-settings');
+			// Keep parent slug: makes WPSettings register as a child of the 'Wicket'
+			// top-level menu (Wicket_Admin::wicket_admin_menu, admin_menu p10).
+			// Relabel the submenu 'Settings' instead of the default 'Wicket Settings',
+			// so it no longer duplicates WP's auto-inserted 'Wicket' parent link
+			// (both pointed at the same wicket-settings slug, producing two entries).
+			$settings->set_menu_parent_slug('wicket-settings');
+			$settings->set_menu_title(__('Settings', 'wicket'));
 
             /*
              * Priority-based tab registration.


### PR DESCRIPTION
## What

Renames the `wicket-settings` submenu from "Wicket Settings" to "Settings" in the WPSettings registration.

## Why

The submenu's `menu_slug` (`wicket-settings`) equals its `parent_slug`, which WP renders alongside its auto-inserted parent link (labeled "Wicket"). With the lib's default title "Wicket Settings", the parent read as a duplicate: two entries pointing at the same destination.

Relabeling to "Settings" makes the child distinct from the parent without changing any slug, capability, or callback. Keeping the parent slug intact is deliberate: dropping it makes the WPSettings lib spawn its own top-level `add_menu_page` with the same slug, which collides with `Wicket_Admin::wicket_admin_menu` and produces a second primary menu (verified live).

Allows this to be cleaner, WP-like:

<img width="1318" height="502" alt="image" src="https://github.com/user-attachments/assets/dc8a9a60-db0c-40b6-93bd-6c4b3addb71f" />

## How

One line added in `Wicket_Settings::register_wicket_settings`:

```php
$settings->set_menu_parent_slug('wicket-settings');
$settings->set_menu_title(__('Settings', 'wicket'));
```

Combined with `wicket-wp-importer` registering its submenu at `admin_menu` priority 21 (after this page at p20), the Wicket parent now reads cleanly as:

- Wicket
  - Settings
  - Importer

with no duplicate parent-link child.

## Testing

- [x] Local: refreshed wp-admin sidebar; confirmed single Wicket parent menu, children `Settings` then `Importer`, no orphan "Wicket" child.
- [x] Clicked Settings; tabs and sections render as before.

## Task

https://app.asana.com/1/1138832104141584/task/1215641900481428?focus=true
