### PR TITLE
fix(deps): Requires Plugins header must declare advanced-custom-fields-pro

### DIFF
--- a/wicket.php
+++ b/wicket.php
@@ -11,7 +11,7 @@
  * Domain Path: /languages
  * Requires at least: 6.6
  * Requires PHP: 8.1
- * Requires Plugins: advanced-custom-fields
+ * Requires Plugins: advanced-custom-fields-pro
  */
 if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.


### PR DESCRIPTION
## What

Restores the `Requires Plugins` header back to `advanced-custom-fields-pro`. One-line change in `wicket.php`.

This revisits commit d7885abe, which switched the header to the free ACF slug (`advanced-custom-fields`). While reviewing the dependency chain I found that base-plugin does rely on Pro-only ACF features in two places, and the free-slug header also blocks the wicket-warden CI WordPress suite from bootstrapping. Happy to discuss if any of the reasoning below is off.

## Why

### Flexible Content field (Pro-only)

`includes/components/social-links.php` renders the `social_media_links` field via the Flexible Content API:

```php
// social-links.php:14
$field = get_field_object('social_media_links', 'option');
// social-links.php:23,25
if (have_rows('social_media_links', 'option')) :
    while (have_rows('social_media_links', 'option')) :
        the_row();
// social-links.php:28,29 — get_row_layout() switches on the active layout
$icon = 'fab fa-' . get_row_layout() . ' fa-fw';
// social-links.php:30,43 — get_sub_field() reads per-layout values
$icon = get_sub_field('fontawesome_icon_classes');
```

`get_row_layout()` is the Flexible Content layout-switcher. Flexible Content is a Pro-only field type. With free ACF the field group loads but the Flexible Content field is not selectable or editable, so the social-links component renders empty.

### ACF Blocks (Pro-only)

Three blocks ship under `includes/blocks/`:

- `create-account/block.json`
- `create-account-no-password/block.json`
- `display-settings/block.json`

Each declares the ACF Blocks schema key:

```json
"acf": {
    "mode": "preview",
    "renderTemplate": "render.php"
}
```

Registration is hooked on `acf/init` in `src/Blocks.php:35` and dispatched via `register_block_type()` against the block.json files in `includes/wicket-blocks.php`. The ACF Blocks framework (metadata-based Gutenberg blocks using the `"acf"` block.json schema) is a Pro-only feature, so without ACF Pro the editor does not recognise these blocks or process their render templates.

### CI bootstrap failure

The wicket-warden CI WordPress suite resolves dependencies by directory name. With the free-slug header it looks for a `advanced-custom-fields` directory, does not find it (only `advanced-custom-fields-pro` is installed), and fatals before the suite can run:

```
PHP Fatal error:  Uncaught RuntimeException: Required plugin directory is missing: advanced-custom-fields
  in .../orchestration/wordpress-bootstrap.php:209
```

Unit + Integration suites pass (1147/1147) but the WordPress suite cannot bootstrap, so the whole run exits 255. A temporary fallback was added to the wicket-warden bootstrap so the suite runs regardless of how this lands, but the cleanest fix is for the header to match the installed directory.

CI run: https://github.com/industrialdev/wicket-warden/actions/runs/28876460050/job/85653138877

### Downstream consumer

`wicket-wp-account-centre` declares in its own header:

```
Requires Plugins: wicket-wp-base-plugin, advanced-custom-fields-pro
```

ACC depends on base-plugin (so the dependency chain applies transitively), and ACC itself ships 19 ACF Blocks under `includes/blocks/` (acc-base-block, ac-additional-info, ac-callout, ac-individual-profile, ac-manage-preferences, ac-org-logo, ac-org-profile, ac-org-search-select, ac-password, ac-profile-picture, ac-touchpoint-{cvent,event-calendar,maple,microspec,moodle,pheedloop,vitalsource,zoom}, ac-welcome). Every one declares the `"acf"` block.json schema key. Aligning the base-plugin header with ACC's keeps the two declarations consistent.

## On the runtime filter

ACF Pro registers a `wp_plugin_dependencies_slug` filter at runtime that maps itself onto the free slug, so real WordPress does accept `advanced-custom-fields` as satisfied by Pro. The header change here is about describing the actual requirement in the plugin file itself, so installs that only have free ACF surface the missing dependency at activation rather than silently shipping with a broken social-links component and non-functional admin blocks. Open to other takes on whether the runtime filter is enough.

## How

Single-line header change. No logic, no API, no behaviour change beyond WordPress's dependency declaration. Matches the actual plugin directory name and the dependency already declared by `wicket-wp-account-centre`.

## Testing

- [x] `php -l wicket.php` clean
- [x] Header now reads `Requires Plugins: advanced-custom-fields-pro`
- [x] Resolves the wicket-warden CI bootstrap failure (the resolver finds the `advanced-custom-fields-pro` directory directly)
- [x] wicket-warden QA bootstrap carries a temporary fallback (ACF free/Pro slug interchangeability) so the suite passes regardless of how this lands
