### PR TITLE
fix(orgss): relabel disabled search-result button to Already Selected

### DIFF
--- a/includes/components/org-search-select.php
+++ b/includes/components/org-search-select.php
@@ -786,6 +786,7 @@ if (!$is_wicket_theme) {
                       'x-bind:aria-disabled="(isOrgAlreadyASelectableConnection(result.id)
                 || (disableSelectingOrgsWithActiveMembership && result.active_membership && !activeMembershipSeatMessagingEnabled)) ? \'true\' : \'false\'"',
                       'x-bind:tabindex="(disableSelectingOrgsWithActiveMembership && result.active_membership && !activeMembershipSeatMessagingEnabled) ? \'-1\' : \'0\'"',
+                      'x-text="isOrgAlreadyASelectableConnection(result.id) ? \'✓ ' . esc_js(__('Already Selected', 'wicket')) . '\' : \'' . esc_js(__('Select', 'wicket')) . '\'"',
                   ],
               ]); ?>
               <div class="component-org-search-select__active-membership-inline-message"


### PR DESCRIPTION
## What

In the org-search-select search results, when an org is already one of the user's current connections, the "Select" button greys out but kept the misleading "Select" label. This changes the label to "Already Selected" for that disabled state.

## Why

The disabled button gave no signal that the org was already linked. Users saw a greyed "Select" with no explanation. The label itself now carries the reason, no extra alert box needed. This mirrors the existing "Selected" treatment on the current-orgs card.

## How

Single `x-text` binding on the search-result "Select" button:
- `isOrgAlreadyASelectableConnection(result.id)` true -> "Already Selected"
- otherwise -> "Select"

No other disabled-reason paths were touched. The active-membership hard-block case keeps its own existing inline message.

<img width="1688" height="1130" alt="image" src="https://github.com/user-attachments/assets/9fce389d-b38e-47fc-af2d-6e1bda3e07ba" />

## Testing

- [x] PHP lint clean (`php -l`)
- [x] Verified on NJBIA staging at `/organization-membership-onboarding/`: searching an org already in the user's list renders a disabled button reading "Already Selected"

Closes the ORGSS UX gap surfaced in NJBIA task WWID-1664.
