### PR TITLE
fix(connections): end-date instead of hard-delete on end-date validation error

### DIFF
--- a/includes/helpers/helper-connections.php
+++ b/includes/helpers/helper-connections.php
@@ -130,13 +130,65 @@ function wicket_update_connection_attributes(string $connection_id, array $attri
         return $updated_connection;
     } catch (Exception $e) {
         $error_message = $e->getMessage();
-        if (strpos($error_message, 'must be before') !== false) {
-            // This is a special case where the end date is being set to the same day as the start date
-            // So we need to simply remove the connection and return true
-            wicket_remove_connection($connection_id);
 
-            return true;
+        // The MDP API requires ends_at to be strictly after starts_at. When the requested
+        // ends_at is not after starts_at (same-day add+remove, same-second timestamps, or a
+        // start date at/after the requested end), the PATCH is rejected with a 422 carrying
+        // "must be before" / "must be after" validation errors.
+        //
+        // Previously this branch HARD-DELETED the connection, destroying history and breaking
+        // the roster contract that removal end-dates a relationship. End-date instead by
+        // clamping ends_at to one second after starts_at and retrying once. If the retry also
+        // fails, leave the connection intact and report failure. Never delete here.
+        if (strpos($error_message, 'must be before') !== false || strpos($error_message, 'must be after') !== false) {
+            $starts_at = $merged_attributes['starts_at'] ?? null;
+            $starts_ts = $starts_at !== null ? strtotime((string) $starts_at) : false;
+
+            if ($starts_ts !== false) {
+                $merged_attributes['ends_at'] = gmdate('Y-m-d\TH:i:s\Z', $starts_ts + 1);
+
+                try {
+                    $retry_payload = [
+                        'data' => [
+                            'attributes'    => $merged_attributes,
+                            'id'            => $connection_id,
+                            'relationships' => [
+                                'from' => $current_connection_info['data']['relationships']['from'],
+                                'to'   => $current_connection_info['data']['relationships']['to'],
+                            ],
+                            'type'          => $current_connection_info['data']['type'],
+                        ],
+                    ];
+
+                    return $client->patch('connections/' . $connection_id, ['json' => $retry_payload]);
+                } catch (Exception $retry_e) {
+                    Wicket()->log()->error('[wicket-base-helper] wicket_update_connection_attributes: end-date clamp retry failed, connection left intact', [
+                        'source'        => 'wicket-base',
+                        'connection_id' => $connection_id,
+                        'starts_at'     => $starts_at,
+                        'error'         => $retry_e->getMessage(),
+                    ]);
+
+                    return false;
+                }
+            }
+
+            Wicket()->log()->error('[wicket-base-helper] wicket_update_connection_attributes: cannot end-date (no starts_at), connection left intact', [
+                'source'         => 'wicket-base',
+                'connection_id'  => $connection_id,
+                'original_error' => $error_message,
+            ]);
+
+            return false;
         }
+
+        // Unhandled PATCH error (not a date-ordering validation). Log so a future MDP
+        // message-wording change does not silently disable the end-date clamp branch above.
+        Wicket()->log()->error('[wicket-base-helper] wicket_update_connection_attributes: unhandled PATCH error', [
+            'source'         => 'wicket-base',
+            'connection_id'  => $connection_id,
+            'original_error' => $error_message,
+        ]);
 
         return false;
     }


### PR DESCRIPTION
## What
Removes the silent hard-delete fallback from `wicket_update_connection_attributes()` and replaces it with an end-date clamp-and-retry.

## Why
When a removal set `ends_at` to a value the MDP API rejected (it requires `ends_at` strictly after `starts_at`, triggered by same-day add+remove, same-second timestamps, or a future-dated `starts_at`), the old catch block called `wicket_remove_connection()` and returned `true`. The relationship vanished instead of being end-dated, and the caller reported success. ESCRS contacts roster QA caught this: removing a contact deleted the relationship and its history.

## How
- On a 422 whose error carries `must be before` / `must be after`, clamp `ends_at` to one second after `starts_at` and retry the PATCH once.
- If the retry fails or `starts_at` is unavailable, log and return `false`. The connection is left intact in every failure path. Never delete from the end-date path.
- Added a log line on the unhandled-error fall-through so a future MDP message reword cannot silently disable the clamp branch.
- Dropped a redundant `!empty($client)` guard (the client is validated at the top of the function).

The 1-second window is semantically correct: `active_at` uses an inclusive `tsrange`, so a `[starts_at, starts_at+1s]` connection reads as inactive for all current-state queries. History is preserved.

`wicket_remove_connection()` and its explicit callers are untouched. Legitimate hard deletes remain available where intended:
- `Rest.php` `terminate_relationship` (opt-in via `removeRelationship: true`; the default branch already end-dates)
- Gravity Forms test-cleanup endpoint (triple-gated to dev/staging)

## Testing
- [x] Verified live on ESCRS staging: `ends_at == starts_at` now clamps to `starts_at+1s`; the connection survives as `active=false` instead of being deleted.
- [x] Peer-reviewed for blast radius: ESCRS membership roster uses `person_memberships` (not this helper), so member removal is unaffected. Only connection-ending paths (contacts roster, cascade-mode sites) are touched.

https://app.asana.com/1/1138832104141584/task/1211650612268505?focus=true
