### PR TITLE
feat(ci): auto version bump and tag on merge to main

### DIFF
--- a/.ci/version-bump.php
+++ b/.ci/version-bump.php
@@ -1,0 +1,242 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Version bumper for Wicket WordPress plugins.
+ *
+ * Source of truth for the current version is composer.json. The new version is
+ * written to composer.json and the main plugin file's header (the root *.php
+ * that contains a "Plugin Name:" header), which is auto-detected.
+ *
+ * Usage:
+ *   php .ci/version-bump.php patch      # 2.4.10 -> 2.4.11
+ *   php .ci/version-bump.php minor      # 2.4.10 -> 2.5.0
+ *   php .ci/version-bump.php major      # 2.4.10 -> 3.0.0
+ *   php .ci/version-bump.php 2.4.11     # set an explicit version
+ *   php .ci/version-bump.php            # prompt interactively
+ *
+ * On success the resolved version is printed to STDOUT as the last line, so CI
+ * can capture it with: NEW_VERSION="$(php .ci/version-bump.php patch | tail -1)"
+ */
+
+class VersionBumper
+{
+    private string $currentVersion;
+    private array $filesToUpdate = [];
+
+    public function __construct()
+    {
+        if (!$this->getCurrentVersion()) {
+            exit(1);
+        }
+
+        $this->filesToUpdate = ['composer.json'];
+
+        $mainFile = $this->detectMainPluginFile();
+        if ($mainFile !== null) {
+            $this->filesToUpdate[] = $mainFile;
+        } else {
+            fwrite(STDERR, "Warning: could not auto-detect main plugin file (no root *.php with a 'Plugin Name:' header).\n");
+        }
+    }
+
+    private function getCurrentVersion(): bool
+    {
+        if (!file_exists('composer.json')) {
+            fwrite(STDERR, "Error: composer.json not found in current directory.\n");
+            return false;
+        }
+
+        $composerJson = json_decode(file_get_contents('composer.json'), true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            fwrite(STDERR, 'Error: Unable to parse composer.json: ' . json_last_error_msg() . "\n");
+            return false;
+        }
+
+        if (!isset($composerJson['version'])) {
+            fwrite(STDERR, "Error: No version field found in composer.json\n");
+            return false;
+        }
+
+        $this->currentVersion = $composerJson['version'];
+        return true;
+    }
+
+    /**
+     * Find the main plugin file: a *.php in the current directory whose header
+     * contains "Plugin Name:".
+     */
+    private function detectMainPluginFile(): ?string
+    {
+        foreach (glob('*.php') ?: [] as $file) {
+            $head = file_get_contents($file, false, null, 0, 4096);
+            if ($head !== false && preg_match('/Plugin Name:\s*\S/i', $head)) {
+                return $file;
+            }
+        }
+
+        return null;
+    }
+
+    private function validateNewVersion(string $newVersion): bool
+    {
+        $semverPattern = '/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/';
+
+        if (!preg_match($semverPattern, $newVersion)) {
+            fwrite(STDERR, "Error: Invalid version format. Please use semantic versioning (e.g., 1.2.3)\n");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Given the current version and a bump level, compute the next version.
+     * Pre-release / build metadata on the current version is dropped.
+     */
+    private function computeBump(string $level): ?string
+    {
+        if (!preg_match('/^(\d+)\.(\d+)\.(\d+)/', $this->currentVersion, $m)) {
+            fwrite(STDERR, "Error: current version '{$this->currentVersion}' is not plain X.Y.Z; cannot compute a {$level} bump.\n");
+            return null;
+        }
+
+        [$major, $minor, $patch] = [(int) $m[1], (int) $m[2], (int) $m[3]];
+
+        switch ($level) {
+            case 'major':
+                return ($major + 1) . '.0.0';
+            case 'minor':
+                return $major . '.' . ($minor + 1) . '.0';
+            case 'patch':
+                return $major . '.' . $minor . '.' . ($patch + 1);
+        }
+
+        return null;
+    }
+
+    private function resolveNewVersion(?string $arg): ?string
+    {
+        if ($arg === null || $arg === '') {
+            fwrite(STDERR, 'Enter new version (semver) or bump level [patch|minor|major]: ');
+            $arg = trim((string) fgets(STDIN));
+        }
+
+        if (in_array($arg, ['patch', 'minor', 'major'], true)) {
+            return $this->computeBump($arg);
+        }
+
+        return $arg;
+    }
+
+    private function updateVersionInFile(string $filePath, string $newVersion): bool
+    {
+        if (!file_exists($filePath)) {
+            fwrite(STDERR, "Warning: File not found: {$filePath}\n");
+            return false;
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            fwrite(STDERR, "Error: Unable to read file: {$filePath}\n");
+            return false;
+        }
+
+        $extension = pathinfo($filePath, PATHINFO_EXTENSION);
+        $updated = false;
+
+        switch ($extension) {
+            case 'json':
+                $pattern = '/"version":\s*"' . preg_quote($this->currentVersion, '/') . '"/';
+                $newContent = preg_replace($pattern, '"version": "' . $newVersion . '"', $content, -1, $count);
+                $updated = $count > 0;
+                break;
+            case 'php':
+                $newContent = $content;
+                $versionPatternPart = '[0-9a-zA-Z\\.-]+';
+
+                $docblockPattern = '/(^\s*\*\s*Version:\s*)' . $versionPatternPart . '/m';
+                $tempContent = preg_replace($docblockPattern, '${1}' . $newVersion, $content, -1, $count1);
+
+                if ($count1 > 0) {
+                    $newContent = $tempContent;
+                    $updated = true;
+                } else {
+                    $plainHeaderPattern = '/(Version:\s*)' . $versionPatternPart . '/i';
+                    $tempContent = preg_replace($plainHeaderPattern, '${1}' . $newVersion, $content, -1, $count2);
+                    if ($count2 > 0) {
+                        $newContent = $tempContent;
+                        $updated = true;
+                    }
+                }
+                break;
+            default:
+                $pattern = '/' . preg_quote($this->currentVersion, '/') . '/';
+                $newContent = preg_replace($pattern, $newVersion, $content, -1, $count);
+                $updated = $count > 0;
+        }
+
+        if ($newContent === null) {
+            fwrite(STDERR, "Error: Pattern replacement failed in {$filePath}\n");
+            return false;
+        }
+
+        if (!$updated) {
+            fwrite(STDERR, "Warning: No version string found in {$filePath}\n");
+            return false;
+        }
+
+        if (file_put_contents($filePath, $newContent) === false) {
+            fwrite(STDERR, "Error: Unable to write to file: {$filePath}\n");
+            return false;
+        }
+
+        return true;
+    }
+
+    public function run(): void
+    {
+        global $argv;
+
+        fwrite(STDERR, "Current version: {$this->currentVersion}\n");
+
+        $newVersion = $this->resolveNewVersion($argv[1] ?? null);
+
+        if ($newVersion === null || !$this->validateNewVersion($newVersion)) {
+            exit(1);
+        }
+
+        if ($newVersion === $this->currentVersion) {
+            fwrite(STDERR, "Error: new version equals current version ({$newVersion}); nothing to do.\n");
+            exit(1);
+        }
+
+        fwrite(STDERR, "New version: {$newVersion}\n");
+
+        $successCount = 0;
+        foreach ($this->filesToUpdate as $file) {
+            if ($this->updateVersionInFile($file, $newVersion)) {
+                fwrite(STDERR, "Updated version in {$file}\n");
+                $successCount++;
+            }
+        }
+
+        if ($successCount === 0) {
+            fwrite(STDERR, "Error: No files were updated\n");
+            exit(1);
+        }
+
+        if ($successCount !== count($this->filesToUpdate)) {
+            fwrite(STDERR, "{$successCount} out of " . count($this->filesToUpdate) . " files were updated\n");
+        }
+
+        fwrite(STDERR, "Version bump completed: {$this->currentVersion} -> {$newVersion}\n");
+
+        // Machine-readable result on STDOUT (last line) for CI capture.
+        echo $newVersion . "\n";
+    }
+}
+
+$bumper = new VersionBumper();
+$bumper->run();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Auto version bump & tag
+
+# Bumps the plugin version and pushes a matching git tag whenever a PR is
+# merged into main. Runs AFTER merge, so the version is computed serially from
+# main and can never collide with a version chosen inside a parallel PR.
+#
+# Bump level (default: patch). Override per-release with a marker anywhere in
+# the merge commit message. With GitHub's default squash-merge the PR title
+# becomes that message, so the marker can just go in the PR title:
+#   - "#major" -> X.0.0
+#   - "#minor" -> x.Y.0
+#   - otherwise -> x.y.Z (patch)
+# Include "#norelease" to skip bumping entirely for this merge.
+#
+# Authenticates as a GitHub App (so releases are never tied to a person). The
+# App needs "Contents: Read and write" and must be installed on this repo, with
+# these two secrets available to the repo (set them once at the org level and
+# scope them to the plugin repos):
+#   - RELEASE_APP_ID          the App's numeric App ID
+#   - RELEASE_APP_PRIVATE_KEY the App's generated .pem private key (whole file)
+# The App must also be on the branch-protection / ruleset bypass list for main,
+# otherwise the push below is rejected even with write access.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip the workflow's own bump commit to avoid an infinite loop.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve App bot user id
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          USER_ID="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          echo "user-id=$USER_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Determine bump level
+        id: level
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          msg="$COMMIT_MSG"
+          level="patch"
+          if echo "$msg" | grep -qiE '#norelease'; then
+            level="none"
+          elif echo "$msg" | grep -qiE '#major'; then
+            level="major"
+          elif echo "$msg" | grep -qiE '#minor'; then
+            level="minor"
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Resolved bump level: $level"
+
+      - name: Skip if no release requested
+        if: ${{ steps.level.outputs.level == 'none' }}
+        run: echo "::notice::#norelease present; skipping version bump."
+
+      - name: Bump version
+        if: ${{ steps.level.outputs.level != 'none' }}
+        id: bump
+        run: |
+          NEW_VERSION="$(php ./.ci/version-bump.php ${{ steps.level.outputs.level }} | tail -1)"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped to $NEW_VERSION"
+
+      - name: Commit, tag & push
+        if: ${{ steps.level.outputs.level != 'none' }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          BOT_USER_ID: ${{ steps.bot.outputs.user-id }}
+        run: |
+          git config user.name  "${APP_SLUG}[bot]"
+          git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+          git add composer.json ./*.php
+          git commit -m "chore(release): ${NEW_VERSION}"
+          git tag "${NEW_VERSION}"
+          git push origin HEAD:main
+          git push origin "refs/tags/${NEW_VERSION}"
+          echo "::notice::Released ${NEW_VERSION}"

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,10 @@
     "cs:format": "php-cs-fixer fix",
     "cs:lint": "php-cs-fixer fix --dry-run --diff",
     "production": "composer install && composer cs:fix && composer install --no-dev --optimize-autoloader",
-    "setup-hooks": "mkdir -p .git/hooks && cp .ci/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push && echo 'Git hooks installed to .git/hooks/pre-push'"
+    "setup-hooks": "mkdir -p .git/hooks && cp .ci/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push && echo 'Git hooks installed to .git/hooks/pre-push'",
+    "version-bump": "@php ./.ci/version-bump.php"
+  },
+  "scripts-descriptions": {
+    "version-bump": "Bump the plugin version in composer.json and the main plugin file. Pass patch|minor|major or an explicit X.Y.Z."
   }
 }

--- a/docs/engineering/release-automation.md
+++ b/docs/engineering/release-automation.md
@@ -1,0 +1,97 @@
+---
+title: "Release Automation (Auto Version Bump & Tag)"
+audience: [developer]
+source_files: [".github/workflows/release.yml", ".ci/version-bump.php"]
+---
+
+# Release Automation
+
+Every merge into `main` bumps the plugin version and pushes a matching git tag automatically. The bump runs *after* merge, computed serially from `main`, so a version can never collide with one chosen inside a parallel PR. No one needs push access to `main`, and releases are attributed to a GitHub App, not a person.
+
+---
+
+## What happens on merge
+
+1. A PR merges into `main` (push event).
+2. [.github/workflows/release.yml](../../.github/workflows/release.yml) mints a GitHub App token, checks out `main`.
+3. It reads the merge commit message for a bump marker and runs [.ci/version-bump.php](../../.ci/version-bump.php).
+4. It commits `chore(release): x.y.z`, tags that commit `x.y.z`, and pushes both to `main`.
+
+The workflow ignores its own `chore(release):` commits, so it does not loop.
+
+## Choosing the bump level
+
+Default is a **patch** bump (`2.4.10` → `2.4.11`). Override by putting a marker anywhere in the merge commit message. With GitHub's default squash-merge, the PR title becomes that message, so the marker can go in the PR title.
+
+| Marker | Result | Example |
+|---|---|---|
+| _(none)_ | patch | `2.4.10` → `2.4.11` |
+| `#minor` | minor | `2.4.10` → `2.5.0` |
+| `#major` | major | `2.4.10` → `3.0.0` |
+| `#norelease` | no bump, no tag | (skipped) |
+
+## What gets bumped
+
+The version is written to two files, kept in sync:
+
+- `composer.json` `version` field (the source of truth the script reads).
+- The main plugin file header `Version:` (auto-detected: the root `*.php` whose header contains `Plugin Name:`).
+
+`readme.txt` `Stable tag` is intentionally not touched (these plugins are not WP.org-hosted; that field is unused here).
+
+## Local use
+
+The same script backs a Composer command for manual bumps:
+
+```bash
+composer version-bump patch     # 2.4.10 -> 2.4.11
+composer version-bump minor     # 2.4.10 -> 2.5.0
+composer version-bump major     # 2.4.10 -> 3.0.0
+composer version-bump 2.4.11    # set an explicit version
+composer version-bump           # prompt interactively
+```
+
+It only edits files; it does not commit or tag.
+
+---
+
+## One-time setup
+
+The workflow authenticates as a GitHub App so releases are decoupled from any individual account and do not expire like a personal token.
+
+### 1. Create the App (org level)
+
+Org → Settings → Developer settings → GitHub Apps → New GitHub App.
+
+- **Repository permissions → Contents: Read and write** (the only permission needed).
+- Uncheck **Webhook → Active**.
+- Create, then **Generate a private key** (downloads a `.pem`). Note the **App ID**.
+
+### 2. Install the App
+
+Install it on the `industrialdev` org and grant it access to the plugin repositories.
+
+### 3. Store the secrets
+
+Set these as **organization** secrets (Org → Settings → Secrets and variables → Actions), scoped to the plugin repos, so all plugins share one App:
+
+| Secret | Value |
+|---|---|
+| `RELEASE_APP_ID` | the App's numeric App ID |
+| `RELEASE_APP_PRIVATE_KEY` | the full contents of the downloaded `.pem` |
+
+### 4. Allow the App to bypass branch protection
+
+`Contents: write` is not enough on a protected branch. On the `main` branch protection rule (or ruleset), add the App to the **bypass list** ("Allow specified actors to bypass required pull requests"). Without this, the workflow's push to `main` is rejected.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Push rejected: `protected branch` | App not on the bypass list | Add the App to the branch-protection / ruleset bypass list |
+| `Bad credentials` / token step fails | Wrong `RELEASE_APP_ID` or malformed `RELEASE_APP_PRIVATE_KEY` | Re-copy the whole `.pem`, including header/footer lines |
+| Workflow runs but does nothing | `#norelease` in the message, or it was the workflow's own `chore(release):` commit | Expected; check the run log's "Resolved bump level" line |
+| `No version field found in composer.json` | Plugin's `composer.json` has no `version` key | Add a `version` field matching the current header |
+| Wrong file bumped / "No version string found" | Main file not auto-detected (no `Plugin Name:` header in a root `*.php`) | Ensure the main plugin file lives in the repo root with a standard header |

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Technical reference for hooks, filters, architecture, and source-level contracts
 
 - [Centralized Logging](engineering/logging.md) — `WicketWP\Log` usage, log levels, per-plugin wrapper pattern
 - [WooCommerce Email Blocker](engineering/woocommerce-email-blocker.md) — admin email suppression logic, hooks, extension point
+- [Release Automation](engineering/release-automation.md): auto version bump and tag on merge to main, GitHub App setup
 
 ---
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that, on every merge into main, bumps the plugin version (default patch; #minor/#major/#norelease markers override) and pushes a matching git tag pointing at the merge commit.

- .ci/version-bump.php: generalized bumper (auto-detects the main plugin file, updates composer.json + header in sync); accepts a bump level or an explicit version. Exposed as `composer version-bump`.
- .github/workflows/release.yml: authenticates as a GitHub App so releases are not tied to a person; commits chore(release) + tag and pushes to main.
- docs/engineering/release-automation.md: setup, usage, troubleshooting.