### PR TITLE
feat(ci): generate CHANGELOG.md entry on release

### DIFF
--- a/.ci/changelog.php
+++ b/.ci/changelog.php
@@ -1,0 +1,176 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Changelog generator for Wicket WordPress plugins.
+ *
+ * Prepends a section for the given version to CHANGELOG.md, built from the git
+ * commits merged since the most recent tag. Intended to run in CI immediately
+ * after the version bump and before the release commit, so the changelog entry
+ * ships in the same commit the tag points at.
+ *
+ * Usage:
+ *   php .ci/changelog.php 2.4.12                  # range = <last tag>..HEAD
+ *   php .ci/changelog.php 2.4.12 2.4.8..HEAD      # explicit range override
+ *
+ * Every commit type is included (grouped into a section). The only commits
+ * skipped are the bot's own "chore(release):" commits, which are the changelog
+ * commits themselves and would be circular noise. Merge commits are ignored.
+ */
+
+class ChangelogGenerator
+{
+    private const FILE = 'CHANGELOG.md';
+    private const MARKER = '<!-- new releases inserted below this line -->';
+
+    private const HEADER = "# Changelog\n\n"
+        . "All notable changes to this plugin are documented in this file.\n"
+        . "This project adheres to [Semantic Versioning](https://semver.org/).\n\n"
+        . self::MARKER . "\n";
+
+    /** Conventional-commit type => changelog section heading. */
+    private array $typeMap = [
+        'feat' => 'Added',
+        'fix' => 'Fixed',
+        'perf' => 'Performance',
+        'refactor' => 'Changed',
+        'docs' => 'Documentation',
+        'test' => 'Tests',
+        'build' => 'Build',
+        'ci' => 'CI',
+        'chore' => 'Maintenance',
+        'style' => 'Maintenance',
+    ];
+
+    /** Order sections appear in the changelog. Anything else is "Other". */
+    private array $sectionOrder = [
+        'Added',
+        'Changed',
+        'Fixed',
+        'Performance',
+        'Documentation',
+        'Tests',
+        'Build',
+        'CI',
+        'Maintenance',
+        'Other',
+    ];
+
+    public function run(string $newVersion, ?string $rangeOverride = null): void
+    {
+        $range = ($rangeOverride !== null && $rangeOverride !== '') ? $rangeOverride : $this->commitRange();
+        $subjects = $this->commitSubjects($range);
+        $sections = $this->groupSubjects($subjects);
+        $block = $this->renderBlock($newVersion, $sections);
+
+        $this->prepend($block);
+
+        fwrite(STDERR, "Wrote changelog entry for {$newVersion} (" . count($subjects) . " commits from range '{$range}').\n");
+    }
+
+    /** Range = <last tag>..HEAD, or the full history if there are no tags yet. */
+    private function commitRange(): string
+    {
+        $prevTag = trim((string) shell_exec('git describe --tags --abbrev=0 HEAD 2>/dev/null'));
+
+        return $prevTag !== '' ? $prevTag . '..HEAD' : 'HEAD';
+    }
+
+    /** @return string[] commit subject lines, newest first, merges excluded */
+    private function commitSubjects(string $range): array
+    {
+        $cmd = 'git log ' . escapeshellarg($range) . ' --no-merges --pretty=format:%s';
+        $out = (string) shell_exec($cmd);
+
+        $subjects = array_filter(array_map('trim', explode("\n", $out)), static fn ($s) => $s !== '');
+
+        // Skip the bot's own release commits.
+        return array_values(array_filter($subjects, static fn ($s) => !preg_match('/^chore\(release\)/i', $s)));
+    }
+
+    /**
+     * @param string[] $subjects
+     * @return array<string, string[]> section heading => rendered lines
+     */
+    private function groupSubjects(array $subjects): array
+    {
+        $sections = [];
+
+        foreach ($subjects as $subject) {
+            if (preg_match('/^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/', $subject, $m)) {
+                $type = strtolower($m[1]);
+                $scope = $m[2];
+                $breaking = $m[3] === '!';
+                $desc = $m[4];
+                $section = $this->typeMap[$type] ?? 'Other';
+            } else {
+                // Non-conventional subject: keep it verbatim under "Other".
+                $scope = '';
+                $breaking = false;
+                $desc = $subject;
+                $section = 'Other';
+            }
+
+            $line = '- '
+                . ($breaking ? '**BREAKING** ' : '')
+                . ($scope !== '' ? '**' . $scope . ':** ' : '')
+                . $desc;
+
+            $sections[$section][] = $line;
+        }
+
+        return $sections;
+    }
+
+    /** @param array<string, string[]> $sections */
+    private function renderBlock(string $newVersion, array $sections): string
+    {
+        $date = date('Y-m-d');
+        $block = "## [{$newVersion}] - {$date}\n";
+
+        if ($sections === []) {
+            return $block . "\n_Maintenance release; no recorded changes._\n";
+        }
+
+        foreach ($this->sectionOrder as $heading) {
+            if (empty($sections[$heading])) {
+                continue;
+            }
+            $block .= "\n### {$heading}\n" . implode("\n", $sections[$heading]) . "\n";
+        }
+
+        return $block;
+    }
+
+    private function prepend(string $block): void
+    {
+        if (!file_exists(self::FILE)) {
+            file_put_contents(self::FILE, self::HEADER);
+        }
+
+        $content = (string) file_get_contents(self::FILE);
+
+        if (!str_contains($content, self::MARKER)) {
+            // File exists but has no marker: put the header (with marker) on top.
+            $content = self::HEADER . "\n" . ltrim($content);
+        }
+
+        $needle = self::MARKER;
+        $insertAt = strpos($content, $needle) + strlen($needle);
+        $newContent = substr($content, 0, $insertAt) . "\n\n" . rtrim($block) . "\n" . substr($content, $insertAt);
+
+        if (file_put_contents(self::FILE, $newContent) === false) {
+            fwrite(STDERR, "Error: unable to write " . self::FILE . "\n");
+            exit(1);
+        }
+    }
+}
+
+global $argv;
+
+if (empty($argv[1])) {
+    fwrite(STDERR, "Usage: php .ci/changelog.php <new-version>\n");
+    exit(1);
+}
+
+(new ChangelogGenerator())->run(trim($argv[1]), isset($argv[2]) ? trim($argv[2]) : null);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,10 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "Bumped to $NEW_VERSION"
 
+      - name: Generate changelog entry
+        if: ${{ steps.level.outputs.level != 'none' }}
+        run: php ./.ci/changelog.php "${{ steps.bump.outputs.new_version }}"
+
       - name: Commit, tag & push
         if: ${{ steps.level.outputs.level != 'none' }}
         env:
@@ -103,7 +107,7 @@ jobs:
         run: |
           git config user.name  "${APP_SLUG}[bot]"
           git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git add composer.json ./*.php
+          git add composer.json CHANGELOG.md ./*.php
           git commit -m "chore(release): ${NEW_VERSION}"
           git tag "${NEW_VERSION}"
           git push origin HEAD:main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this plugin are documented in this file.
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+<!-- new releases inserted below this line -->

--- a/docs/engineering/release-automation.md
+++ b/docs/engineering/release-automation.md
@@ -1,7 +1,7 @@
 ---
 title: "Release Automation (Auto Version Bump & Tag)"
 audience: [developer]
-source_files: [".github/workflows/release.yml", ".ci/version-bump.php"]
+source_files: [".github/workflows/release.yml", ".ci/version-bump.php", ".ci/changelog.php"]
 ---
 
 # Release Automation
@@ -15,7 +15,8 @@ Every merge into `main` bumps the plugin version and pushes a matching git tag a
 1. A PR merges into `main` (push event).
 2. [.github/workflows/release.yml](../../.github/workflows/release.yml) mints a GitHub App token, checks out `main`.
 3. It reads the merge commit message for a bump marker and runs [.ci/version-bump.php](../../.ci/version-bump.php).
-4. It commits `chore(release): x.y.z`, tags that commit `x.y.z`, and pushes both to `main`.
+4. It runs [.ci/changelog.php](../../.ci/changelog.php) to prepend a `CHANGELOG.md` section for the new version.
+5. It commits `chore(release): x.y.z` (version files + changelog), tags that commit `x.y.z`, and pushes both to `main`.
 
 The workflow ignores its own `chore(release):` commits, so it does not loop.
 
@@ -38,6 +39,30 @@ The version is written to two files, kept in sync:
 - The main plugin file header `Version:` (auto-detected: the root `*.php` whose header contains `Plugin Name:`).
 
 `readme.txt` `Stable tag` is intentionally not touched (these plugins are not WP.org-hosted; that field is unused here).
+
+## Changelog
+
+`CHANGELOG.md` (repo root, [Keep a Changelog](https://keepachangelog.com) style, newest on top) is updated automatically in the same release commit. [.ci/changelog.php](../../.ci/changelog.php) reads the commits merged since the last tag (`git log <last-tag>..HEAD --no-merges`) and prepends one section for the new version.
+
+Every commit type is included and grouped by its conventional prefix. The only commits skipped are the bot's own `chore(release):` commits (they are the changelog commits themselves). Commits with no conventional prefix are listed verbatim under **Other**.
+
+| Prefix | Section | | Prefix | Section |
+|---|---|---|---|---|
+| `feat` | Added | | `test` | Tests |
+| `fix` | Fixed | | `build` | Build |
+| `perf` | Performance | | `ci` | CI |
+| `refactor` | Changed | | `chore`, `style` | Maintenance |
+| `docs` | Documentation | | _(none / unknown)_ | Other |
+
+A `!` in the prefix (e.g. `feat!:`) prefixes the line with **BREAKING**.
+
+New sections are inserted below the `<!-- new releases inserted below this line -->` marker, so the file header stays fixed. Cleaner commit subjects (or squash-merge, so one PR is one line) produce a cleaner changelog.
+
+Regenerate or back-fill a range manually with an explicit range argument:
+
+```bash
+php .ci/changelog.php 2.4.11 2.4.8..2.4.11
+```
 
 ## Local use
 


### PR DESCRIPTION
Extends the release workflow to prepend a CHANGELOG.md section on every tagged release, built from the commits merged since the last tag.

- .ci/changelog.php: groups commits by conventional-commit type (all types included; only the bot's own chore(release) commits are skipped; non-conventional subjects go under "Other"). Accepts an optional explicit range for back-fill/regeneration.
- CHANGELOG.md: seeded with header + insertion marker (starts fresh).
- release.yml: runs the generator between the version bump and the commit; stages CHANGELOG.md alongside the version files.
- docs: document changelog behavior and type mapping.