### PR TITLE
fix: scope role removal to org, handle already-absent roles, log delete errors #patch

### DIFF
--- a/includes/helpers/helper-unsorted.php
+++ b/includes/helpers/helper-unsorted.php
@@ -1973,57 +1973,127 @@ function wicket_assign_role($person_uuid, $role_name, $org_uuid = '')
     return false;
 }
 
+
 /**------------------------------------------------------------------
  * Removes role from person
  * $role_name is the text name of the role
  * The lookup is case sensitive so "prospective AO" and "prospective ao" would be considered different roles
+ * $org_id, when provided, scopes the match to a specific org resource so a
+ * same-named role held at a different org is never deleted.
+ * Idempotent: if the person fetch succeeds but the role is absent, returns true
+ * (the role is already gone, e.g. membership-derived role revoked server-side).
  ------------------------------------------------------------------*/
-function wicket_remove_role($person_uuid, $role_name)
+function wicket_remove_role($person_uuid, $role_name, $org_id = '')
 {
     $client = wicket_api_client();
     $person = wicket_get_person_by_id($person_uuid);
 
+    // Never mask a fetch failure: if the person could not be loaded, the role
+    // absence is untrustworthy. Return false so callers can surface the error.
+    if (!$person) {
+        if (function_exists('wc_get_logger')) {
+            wc_get_logger()->error('wicket_remove_role: person fetch returned empty', [
+                'source' => 'wicket-orgman',
+                'person_uuid' => $person_uuid,
+                'role_name' => $role_name,
+                'org_id' => $org_id,
+            ]);
+        }
+
+        return false;
+    }
+
+    // Normalize included() to a plain iterable array. The SDK returns a
+    // Illuminate\Support\Collection (an object) or null.
+    $included_raw = is_object($person) && method_exists($person, 'included')
+        ? $person->included()
+        : null;
+    $included_items = [];
+    if (is_array($included_raw)) {
+        $included_items = $included_raw;
+    } elseif ($included_raw instanceof \Traversable) {
+        foreach ($included_raw as $inc_item) {
+            $included_items[] = $inc_item;
+        }
+    }
+
     $role_id = '';
-    if ($person) {
-        foreach ($person->included() as $included) {
-            if ($included['type'] == 'roles' && $included['attributes']['name'] == $role_name) {
-                // get the role id for use in the payload below
-                $role_id = $included['id'];
-                break;
+    foreach ($included_items as $included) {
+        if (($included['type'] ?? '') !== 'roles') {
+            continue;
+        }
+        if (($included['attributes']['name'] ?? '') !== $role_name) {
+            continue;
+        }
+        // When org_id is provided, only match roles scoped to that org.
+        if ($org_id !== '') {
+            $resource_id = (string) (
+                $included['relationships']['resource']['data']['id']
+                ?? $included['relationships']['organization']['data']['id']
+                ?? ''
+            );
+            if ($resource_id !== $org_id) {
+                continue;
             }
         }
+        $role_id = $included['id'];
+        break;
     }
 
-    if ($role_id) {
-        // build role payload
-        $payload = [
-            'data' => [
-                [
-                    'type' => 'roles',
-                    'id' => $role_id,
-                ],
-            ],
-        ];
-
-        try {
-            $client->delete("people/$person_uuid/relationships/roles", ['json' => $payload]);
-
-            return true;
-        } catch (Exception $e) {
-            $errors = json_decode($e->getResponse()->getBody())->errors;
-            // echo "<pre>";
-            // print_r($e->getMessage());
-            // echo "</pre>";
-            //
-            // echo "<pre>";
-            // print_r($errors);
-            // echo "</pre>";
-            // die;
+    // Role not found despite a successful person fetch: it is already gone
+    // (e.g. membership-derived role auto-revoked server-side). Treat as success.
+    if ('' === $role_id) {
+        if (function_exists('wc_get_logger')) {
+            wc_get_logger()->info('wicket_remove_role: role already absent, treating as success', [
+                'source' => 'wicket-orgman',
+                'person_uuid' => $person_uuid,
+                'role_name' => $role_name,
+                'org_id' => $org_id,
+            ]);
         }
+
+        return true;
     }
 
-    return false;
+    // build role payload
+    $payload = [
+        'data' => [
+            [
+                'type' => 'roles',
+                'id' => $role_id,
+            ],
+        ],
+    ];
+
+    try {
+        $client->delete("people/$person_uuid/relationships/roles", ['json' => $payload]);
+
+        return true;
+    } catch (Exception $e) {
+        // Safe error extraction: getResponse() may be null for non-HTTP failures.
+        $error_detail = $e->getMessage();
+        if (method_exists($e, 'getResponse') && $e->getResponse()) {
+            $body = (string) $e->getResponse()->getBody();
+            $decoded = json_decode($body, true);
+            if (isset($decoded['errors'])) {
+                $error_detail .= ' | ' . wp_json_encode($decoded['errors']);
+            }
+        }
+        if (function_exists('wc_get_logger')) {
+            wc_get_logger()->error('wicket_remove_role: DELETE request failed', [
+                'source' => 'wicket-orgman',
+                'person_uuid' => $person_uuid,
+                'role_name' => $role_name,
+                'org_id' => $org_id,
+                'role_id' => $role_id,
+                'error' => $error_detail,
+            ]);
+        }
+
+        return false;
+    }
 }
+
 
 /**------------------------------------------------------------------
  * Assign organization membership to person


### PR DESCRIPTION
## What

Rewrites `wicket_remove_role` to scope deletions to the correct org, treat already-absent roles as success, and log DELETE errors instead of swallowing them.

## Why

NJBIA reported that removing an org member holding the base `member` role stacked with additional org roles (org_editor, membership_manager) failed on the first click and succeeded on the second. Investigation surfaced three defects in this function:

1. **Dropped org_id.** Every caller passed `$org_id` as a third argument, but the function signature only accepted two. PHP silently discarded it, so deletion matched by role name across all orgs. A person holding the same role name in two orgs would have the wrong one deleted.
2. **Non-idempotent absence.** When a role was already gone from the person fetch (the membership-linked base role gets revoked server-side when the membership ends), the lookup returned false and aborted the entire roster removal.
3. **Swallowed errors.** The DELETE catch had all output commented out and would fatal on a null `getResponse()` (non-HTTP failures). Genuine delete rejections were invisible.

## How

- `wicket_remove_role($person_uuid, $role_name, $org_id = '')`: the optional third parameter scopes the match to `resource_id === org_id` so a same-named role held at a different org is never touched.
- Guarded idempotency: `!$person` returns false (never masks a fetch failure); role absent with a successful fetch returns true.
- The catch now logs via `wc_get_logger` with null-safe error extraction (`method_exists($e, 'getResponse')` + body decode guard).

## Testing

- PHP lint passes.
- Verified in NJBIA staging: member removal now completes on the first click for accounts holding stacked roles. Previously required two clicks.

## Risk notes

- Backward compatible: `$org_id` defaults to `''`, so existing callers that omit it behave as before (name-only match). All four current callers already pass it.
- The idempotency change (absent = success) only fires after a confirmed successful person fetch. A failed fetch still returns false.

Asana: [NJBIA] Roster Not Deleting Members (WWID-1665).
